### PR TITLE
TSHttpTxnRedoCacheLookup.

### DIFF
--- a/include/ts/experimental.h
+++ b/include/ts/experimental.h
@@ -198,7 +198,27 @@ tsapi TSReturnCode TSHttpTxnCacheLookupCountGet(TSHttpTxn txnp, int *lookup_coun
 tsapi TSReturnCode TSHttpTxnServerRespIgnore(TSHttpTxn txnp);
 tsapi TSReturnCode TSHttpTxnShutDown(TSHttpTxn txnp, TSEvent event);
 tsapi TSReturnCode TSHttpTxnCloseAfterResponse(TSHttpTxn txnp, int should_close);
-tsapi void TSHttpTxnRedoCacheLookup(TSHttpTxn txnp, const char *, const int, const char *, const char *);
+
+/** Do another cache lookup with a different cache key.
+ *
+ * @param txnp Transaction.
+ * @param url URL to use for cache key.
+ * @param length Length of the string in @a url
+ *
+ * @return @c TS_SUCCESS on success, @c TS_ERROR if the @a txnp is invalid or the @a url is
+ * not a valid URL.
+ *
+ * If @a length is negative, @c strlen will be used to determine the length of @a url.
+ *
+ * @a url must be syntactically a URL, but otherwise it is just a string and does not need to
+ * be retrievable.
+ *
+ * This can only be called in a @c TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK callback. To set the cache
+ * key for the first lookup, use @c TSCacheUrlSet.
+ *
+ * @see TSCacheUrlSet
+ */
+tsapi TSReturnCode TSHttpTxnRedoCacheLookup(TSHttpTxn txnp, const char *url, int length);
 
 /****************************************************************************
  *  ??

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -9751,48 +9751,24 @@ TSRegisterProtocolTag(const char *tag)
   return nullptr;
 }
 
-void
-TSHttpTxnRedoCacheLookup(TSHttpTxn txnp, const char *host, const int port, const char *path, const char *query)
+TSReturnCode
+TSHttpTxnRedoCacheLookup(TSHttpTxn txnp, const char *url, int length)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
-  HttpSM *sm             = (HttpSM *)txnp;
+
+  HttpSM *sm             = reinterpret_cast<HttpSM *>(txnp);
   HttpTransact::State *s = &(sm->t_state);
   sdk_assert(s->next_action == HttpTransact::SM_ACTION_CACHE_LOOKUP);
-  s->transact_return_point = nullptr;
 
-  sm->rewind_state_machine();
-
-  TSMBuffer buffer = nullptr;
-  TSMLoc location = nullptr, location2 = nullptr;
-
-  TSHttpTxnClientReqGet(txnp, &buffer, &location);
-  TSHttpHdrUrlGet(buffer, location, &location2);
-
-  // host
-  if (nullptr != host) {
-    const int length = strlen(host);
-    TSUrlHostSet(buffer, location2, host, length);
+  // Because of where this is in the state machine, the storage for the cache_info URL must
+  // have already been initialized and @a lookup_url must be valid.
+  auto result = s->cache_info.lookup_url->parse(url, length < 0 ? strlen(url) : length);
+  if (PARSE_RESULT_DONE == result) {
+    s->transact_return_point = nullptr;
+    sm->rewind_state_machine();
+    return TS_SUCCESS;
   }
-
-  // port
-  if (0 < port) {
-    TSUrlPortSet(buffer, location2, port);
-  }
-
-  // path
-  if (nullptr != path) {
-    const int length = strlen(path);
-    TSUrlPathSet(buffer, location2, path, length);
-  }
-
-  // query
-  if (nullptr != query) {
-    const int length = strlen(query);
-    TSUrlHttpQuerySet(buffer, location2, query, length);
-  }
-
-  TSHandleMLocRelease(buffer, location, location2);
-  TSHandleMLocRelease(buffer, TS_NULL_MLOC, location);
+  return TS_ERROR;
 }
 
 namespace


### PR DESCRIPTION
I think this is a better approach. The changes were too complex to do in comments and I thought I should verify successful compilation. How much have you tested this? I don't have a test run to validate it.

The two big changes are

* Make the API look like `TSCacheKeySet` for consistency.

* Since this is in the core, use the core data structures directly.
