### PR TITLE
👷 Add trafficserver package-name into build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - 9.0.x-netlify
   pull_request:
     branches:
+      - readme-and-settings
       - 7.1.x-netlify
       - 9.0.x-netlify
 jobs:
@@ -52,8 +53,14 @@ jobs:
     outputs:
       release: ${{ steps.info.release }}
     steps:
-      - name: Checkout
+      - name: Checkout Branch
         uses: actions/checkout@v2
+        if: github.base_ref != 'readme-and-settings'
+      - name: Checkout Branch
+        if: github.base_ref == 'readme-and-settings'
+        uses: actions/checkout@v2
+        with:
+          ref: 7.1.x-netlify
       - name: Setup Build Environment
         run: |
           sudo apt update && sudo apt -y upgrade

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
             -Wno-invalid-offsetof
             -Wno-cpp
             -fno-strict-aliasing
+            -Dmy_bool=int
             -mcx16
             ${{ matrix.build-flags }}
       - name: Build TrafficServer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,9 @@ jobs:
             AM_CXXFLAGS: "-O2 -DNDEBUG"
           - build-type: RelWithDebInfo
             AM_CXXFLAGS: "-O2 -ggdb -DNDEBUG"
+    env:
+      CXX: g++-9
+      CC: gcc-9
     outputs:
       release: ${{ steps.info.release }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,6 @@ jobs:
         # TODO: Remove development files from non-dev form
         package-name: [trafficserver-dev, trafficserver]
         build-type: [Debug, Release, RelWithDebInfo]
-        cxx-flags: "-std=c++17 -Wall -Wextra -Wno-deprecated-copy -Wno-ignored-qualifiers -Wno-unused-parameter -Wno-format-truncation -Wno-cast-function-type -Wno-stringop-overflow -Wno-invalid-offsetof -Wno-cpp -fno-strict-aliasing -mcx16"
         include:
           - build-type: Debug
             build-flags: "-Og -ggdb -fno-omit-frame-pointer"
@@ -93,7 +92,21 @@ jobs:
       - name: Generate Configure Script
         run: autoreconf --install --force
         env:
-          CXXFLAGS: ${{ matrix.cxx-flags }} ${{ matrix.build-flags }}
+          CXXFLAGS: >-
+            -std=c++17
+            -Wall
+            -Wextra
+            -Wno-deprecated-copy
+            -Wno-ignored-qualifiers
+            -Wno-unused-parameter
+            -Wno-format-truncation
+            -Wno-cast-function-type
+            -Wno-stringop-overflow
+            -Wno-invalid-offsetof
+            -Wno-cpp
+            -fno-strict-aliasing
+            -mcx16
+            ${{ matrix.build-flags }}
       - name: Configure
         run: >-
           ${{ github.workspace }}/configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,8 +93,6 @@ jobs:
         run: autoreconf --install --force
         env:
           AM_CXXFLAGS: "${{ matrix.AM_CXXFLAGS }} -std=c++17 -Wno-cpp -Wno-deprecated-copy"
-      - name: Create Build Directory # Might not be needed due to autoreconf!
-        run: mkdir -p ${{ github.workspace }}/build
       - name: Configure
         run: ${{ github.workspace }}/configure --prefix=/opt/ts --enable-experimental-plugins
         working-directory: ${{ github.workspace }}/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,8 @@ jobs:
           tcl-dev
       - name: Generate Configure Script
         run: autoreconf --install --force
+        env:
+          AM_CXXFLAGS: "${{ matrix.AM_CXXFLAGS }} -std=c++17 -Wno-cpp -Wno-deprecated-copy"
       - name: Create Build Directory # Might not be needed due to autoreconf!
         run: mkdir -p ${{ github.workspace }}/build
       - name: Configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,7 @@ jobs:
           echo "::set-output name=version::${version}"
       - name: Install to Staging Area
         run: make install DESTDIR=${{github.workspace}}/${{ steps.info.outputs.package }}
+        working-directory: ${{ github.workspace }}/build
       - name: Generate Package Manifest # NOTE: We use an epoch (1:) because we differ from ubuntu versioning
         run: |-
           mkdir -p ${{steps.info.outputs.package}}/DEBIAN/control

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
           CONFIGURE_OPTS: "${{ matrix.CONFIGURE_OPTS }}"
       - name: Build TrafficServer
         run: make -j
+        working-directory: ${{ github.workspace }}/build
         env:
           LSAN_OPTIONS: ${{ matrix.LSAN_OPTIONS }}
       - name: Acquire Package Info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
           AM_CXXFLAGS: "${{ matrix.AM_CXXFLAGS }} -std=c++17 -Wno-cpp -Wno-deprecated-copy"
           CONFIGURE_OPTS: "${{ matrix.CONFIGURE_OPTS }}"
       - name: Build TrafficServer
-        run: make -j
+        run: make -j VERBOSE=1
         working-directory: ${{ github.workspace }}/build
         env:
           LSAN_OPTIONS: ${{ matrix.LSAN_OPTIONS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,13 @@ jobs:
           tcl-dev
       - name: Generate Configure Script
         run: autoreconf --install --force
+      - name: Configure
+        run: >-
+          ${{ github.workspace }}/configure
+          --prefix=/opt/ts
+          --enable-experimental-plugins
+          ${{ matrix.CONFIGURE_OPTS }}
+        working-directory: ${{ github.workspace }}/build
         env:
           CXXFLAGS: >-
             -std=c++17
@@ -107,13 +114,6 @@ jobs:
             -fno-strict-aliasing
             -mcx16
             ${{ matrix.build-flags }}
-      - name: Configure
-        run: >-
-          ${{ github.workspace }}/configure
-          --prefix=/opt/ts
-          --enable-experimental-plugins
-          ${{ matrix.CONFIGURE_OPTS }}
-        working-directory: ${{ github.workspace }}/build
       - name: Build TrafficServer
         run: make -j VERBOSE=1
         working-directory: ${{ github.workspace }}/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
         run: >
           sudo apt install -y
           libjpeg-turbo8-dev
+          libmysqlclient-dev
           libluajit-5.1-dev
           libyaml-cpp-dev
           libunwind8-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,18 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        package-name: trafficserver-dev # Add non -dev to list later
-        build-type: [Debug, Release]
+        # TODO: Remove development files from non-dev form
+        package-name: [trafficserver-dev, trafficserver]
+        build-type: [Debug, Release, RelWithDebInfo]
         include:
           - build-type: Debug
             AM_CXXFLAGS: "-Og -ggdb -fno-omit-frame-pointer"
             CONFIGURE_OPTS: "--enable-asan --enable-debug"
             LSAN_OPTIONS: "detect_leaks=0"
           - build-type: Release
-            AM_CXXFLAGS: "-O2"
+            AM_CXXFLAGS: "-O2 -DNDEBUG"
+          - build-type: RelWithDebInfo
+            AM_CXXFLAGS: "-O2 -ggdb -DNDEBUG"
     outputs:
       release: ${{ steps.info.release }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
         working-directory: ${{ github.workspace }}/build
       - name: Generate Package Manifest # NOTE: We use an epoch (1:) because we differ from ubuntu versioning
         run: |-
-          mkdir -p ${{steps.info.outputs.package}}/DEBIAN/control
+          mkdir -p ${{steps.info.outputs.package}}/DEBIAN
           tee ${{steps.info.outputs.package}}/DEBIAN/control <<- EOF
           Package: netlify-${{ matrix.package-name}}
           Section: devel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           -Wno-stringop-overflow
           -Wno-invalid-offsetof
           -Wno-cpp
-          -fno-strict-aliasing # TODO: Get this removed!
+          -fno-strict-aliasing
           -mcx16
         include:
           - build-type: Debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,20 +41,7 @@ jobs:
         # TODO: Remove development files from non-dev form
         package-name: [trafficserver-dev, trafficserver]
         build-type: [Debug, Release, RelWithDebInfo]
-        cxx-flags: >-
-          -std=c++17
-          -Wall
-          -Wextra
-          -Wno-deprecated-copy
-          -Wno-ignored-qualifiers
-          -Wno-unused-parameter
-          -Wno-format-truncation
-          -Wno-cast-function-type
-          -Wno-stringop-overflow
-          -Wno-invalid-offsetof
-          -Wno-cpp
-          -fno-strict-aliasing
-          -mcx16
+        cxx-flags: "-std=c++17 -Wall -Wextra -Wno-deprecated-copy -Wno-ignored-qualifiers -Wno-unused-parameter -Wno-format-truncation -Wno-cast-function-type -Wno-stringop-overflow -Wno-invalid-offsetof -Wno-cpp -fno-strict-aliasing -mcx16"
         include:
           - build-type: Debug
             build-flags: "-Og -ggdb -fno-omit-frame-pointer"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,15 +41,29 @@ jobs:
         # TODO: Remove development files from non-dev form
         package-name: [trafficserver-dev, trafficserver]
         build-type: [Debug, Release, RelWithDebInfo]
+        cxx-flags: >-
+          -std=c++17
+          -Wall
+          -Wextra
+          -Wno-deprecated-copy
+          -Wno-ignored-qualifiers
+          -Wno-unused-parameter
+          -Wno-format-truncation
+          -Wno-cast-function-type
+          -Wno-stringop-overflow
+          -Wno-invalid-offsetof
+          -Wno-cpp
+          -fno-strict-aliasing # TODO: Get this removed!
+          -mcx16
         include:
           - build-type: Debug
-            AM_CXXFLAGS: "-Og -ggdb -fno-omit-frame-pointer"
+            build-flags: "-Og -ggdb -fno-omit-frame-pointer"
             CONFIGURE_OPTS: "--enable-asan --enable-debug"
             LSAN_OPTIONS: "detect_leaks=0"
           - build-type: Release
-            AM_CXXFLAGS: "-O2 -DNDEBUG"
+            build-flags: "-O2 -DNDEBUG"
           - build-type: RelWithDebInfo
-            AM_CXXFLAGS: "-O2 -ggdb -DNDEBUG"
+            build-flags: "-O2 -ggdb -DNDEBUG"
     env:
       CXX: g++-9
       CC: gcc-9
@@ -92,13 +106,14 @@ jobs:
       - name: Generate Configure Script
         run: autoreconf --install --force
         env:
-          AM_CXXFLAGS: "${{ matrix.AM_CXXFLAGS }} -std=c++17 -Wno-cpp -Wno-deprecated-copy"
+          CXXFLAGS: ${{ matrix.cxx-flags }} ${{ matrix.build-flags }}
       - name: Configure
-        run: ${{ github.workspace }}/configure --prefix=/opt/ts --enable-experimental-plugins
+        run: >-
+          ${{ github.workspace }}/configure
+          --prefix=/opt/ts
+          --enable-experimental-plugins
+          ${{ matrix.CONFIGURE_OPTS }}
         working-directory: ${{ github.workspace }}/build
-        env:
-          AM_CXXFLAGS: "${{ matrix.AM_CXXFLAGS }} -std=c++17 -Wno-cpp -Wno-deprecated-copy"
-          CONFIGURE_OPTS: "${{ matrix.CONFIGURE_OPTS }}"
       - name: Build TrafficServer
         run: make -j VERBOSE=1
         working-directory: ${{ github.workspace }}/build


### PR DESCRIPTION
👷 Add RelWithDebInfo build-type
These names are taken from CMake. At some point we'll be moving to TrafficServer 9.0.x and we'll start working on moving the build to CMake properly. This will eventually allow us to reduce the complexity of the workflow file for GitHub Actions. However, until that time we're just going to mirror the build itself.
🐛 Fix AM_CXXFLAGS under Release not using -DNDEBUG