### PR TITLE
Finish up ability to upload packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,14 @@ jobs:
         run: |-
           shopt -s globstar
           set -e
-          for package in $(ls ${{github.workspace}}/packages/**/**.deb)
+          for package in **/**.deb
           do
             directory=$(dirname ${package})
             filename=$(basename ${package})
             pushd ${directory}
             echo Fixing up ${package}
             fakeroot mkdir -p tmp
-            fakeroot dpkg-deb -R ${filename}
+            fakeroot dpkg-deb -R ${package}
             sed -i '$s:netlify.*:${{ needs.build.outputs.release}}:' tmp/DEBIAN/control
             fakeroot dpkg-deb --build tmp temporary.deb
             fakeroot dpkg-name temporary.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
             pushd ${directory}
             echo Fixing up ${package}
             fakeroot mkdir -p tmp
-            fakeroot dpkg-deb -R ${package}
+            fakeroot dpkg-deb -R ${package} tmp
             sed -i '$s:netlify.*:${{ needs.build.outputs.release}}:' tmp/DEBIAN/control
             fakeroot dpkg-deb --build tmp temporary.deb
             fakeroot dpkg-name temporary.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,21 +28,25 @@ jobs:
         run: |-
           echo "release: ${{ needs.build.outputs.release }}"
           echo "version: ${{ needs.build.outputs.version }}"
-      - name: Generate Fixup Script
+      - name: Fixup Package Versions
+        shell: bash
         run: |-
-          tee fixup.sh <<- EOF
-            set -e
-            echo Fixing up ${{ github.workspace }}/$(basename $1)
+          shopt -s globstar
+          set -e
+          for package in ls **/**.deb
+          do
+            directory=$(dirname ${package})
+            filename=$(basename ${package})
+            pushd ${directory}
+            echo Fixing up ${package}
             fakeroot mkdir -p tmp
-            fakeroot dpkg-deb -R $1 tmp
+            fakeroot dpkg-deb -R ${filename}
             sed -i '$s:netlify.*:${{ needs.build.outputs.release}}:' tmp/DEBIAN/control
             fakeroot dpkg-deb --build tmp temporary.deb
             fakeroot dpkg-name temporary.deb
-            rm $1 # prevent duplicates
-          EOF
-      - name: Fixup Package Versions and Filenames
-        id: fixup
-        run: find . -type f -name "*.deb" -execdir bash ${{ github.workspace }}/fixup.sh {} \;
+            rm ${package}
+            popd
+          done
       #- name: Create Release
       #  uses: actions/create-release@v1
       #  id: create-release
@@ -58,7 +62,7 @@ jobs:
           script: |
             const fs = require('fs');
             const contentType = 'application/vnd.debian.binary-package';
-            const uploadUrl = '';#'${{ steps.create-release.outputs.upload_url }}';
+            const uploadUrl = ''; //'${{ steps.create-release.outputs.upload_url }}';
             const directories = ['Debug', 'Release', 'RelWithDebInfo']
               .flatMap(build => [`trafficserver-dev-${build}`, `trafficserver-${build}`]);
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: |-
           shopt -s globstar
           set -e
-          for package in ls **/**.deb
+          for package in $(ls ${{github.workspace}}/packages/**/**.deb)
           do
             directory=$(dirname ${package})
             filename=$(basename ${package})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         id: create-release
         with:
           release_name: ${{ needs.build.outputs.version }}
-          prerelease: ${{ github.event_name == "pull_request" }}
+          prerelease: ${{ github.event_name == 'pull_request' }}
           tag_name: ${{needs.build.outputs.version}}-${{ needs.build.outputs.release }}
       - name: Upload Debian Package
         uses: actions/github-script@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,13 +69,15 @@ jobs:
             // Get each file that we've uploaded as an artifact
             for (const directory of directories) {
               for (const file of fs.readdirSync(`${{github.workspace}}/packages/${directory}`)) {
-                const contentLength = fs.statSync(file).size;
+                const path = `${{github.workspace}}/packages/${directory}/${file}`
+                const contentLength = fs.statSync(path).size;
                 const headers = { 'content-type': contentType, 'content-length': contentLength };
                 const inputs = {
                   url: uploadUrl,
                   headers,
+                  label: directory,
                   name: file,
-                  file: fs.readFileSync(file)
+                  file: fs.readFileSync(path)
                 };
                 core.info(`${inputs}`);
                 //const response = await github.repos.uploadReleaseAsset(inputs);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,13 @@ jobs:
             rm -r tmp
             popd
           done
-      #- name: Create Release
-      #  uses: actions/create-release@v1
-      #  id: create-release
-      #  with:
-      #    release_name: ${{ needs.build.outputs.version }}
-      #    prerelease: ${{ github.event_name == "pull_request" }}
-      #    tag_name: ${{ github.ref }}
-      # We can't use upload-release-asset because there are multiple files
+      - name: Create Release
+        uses: actions/create-release@v1
+        id: create-release
+        with:
+          release_name: ${{ needs.build.outputs.version }}
+          prerelease: ${{ github.event_name == "pull_request" }}
+          tag_name: ${{needs.build.outputs.version}}-${{ needs.build.outputs.release }}
       - name: Upload Debian Package
         uses: actions/github-script@v2
         with:
@@ -63,10 +62,9 @@ jobs:
           script: |-
             const fs = require('fs');
             const contentType = 'application/vnd.debian.binary-package';
-            const uploadUrl = ''; //'${{ steps.create-release.outputs.upload_url }}';
+            const uploadUrl = '${{ steps.create-release.outputs.upload_url }}';
             const directories = ['Debug', 'Release', 'RelWithDebInfo']
               .flatMap(build => [`trafficserver-dev-${build}`, `trafficserver-${build}`]);
-
             // Get each file that we've uploaded as an artifact
             for (const directory of directories) {
               for (const file of fs.readdirSync(`${{github.workspace}}/packages/${directory}`)) {
@@ -82,8 +80,10 @@ jobs:
                   name: file,
                   file: fs.readFileSync(path)
                 };
-                core.info(`${inputs}`);
-                //const response = await github.repos.uploadReleaseAsset(inputs);
+                const {
+                  data: { browser_download_url: download_url }
+                } = await github.repos.uploadReleaseAsset(inputs);
+                core.info(`Asset ${file} with label ${directory} is available at ${download_url}`);
               }
             }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Create Release
         uses: actions/create-release@v1
         id: create-release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           release_name: ${{ needs.build.outputs.version }}
           prerelease: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,13 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: packages
+      - name: Generate Package Version
+        id: package
+        run: |-
+          seconds=$(date -u --date="1970-01-01 UTC $(date -u +%T)" +%s)
+          release=netlify+$(date +'%Y.%m.%d')
+          echo "::set-output name=release::${release}~${seconds}"
+          echo "::set-output name=tag::${release}.${seconds}"
       - name: Display Artifacts
         run: ls -R
       - name: Display Build Step Outputs
@@ -41,7 +48,7 @@ jobs:
             echo Fixing up ${package}
             fakeroot mkdir -p tmp
             fakeroot dpkg-deb -R ${filename} tmp
-            sed -i '$s:netlify.*:${{ needs.build.outputs.release}}:' tmp/DEBIAN/control
+            sed -i '$s:netlify.*:${{ steps.package.outputs.release }}:' tmp/DEBIAN/control
             fakeroot dpkg-deb --build tmp temporary.deb
             fakeroot dpkg-name temporary.deb
             rm ${filename}
@@ -56,7 +63,7 @@ jobs:
         with:
           release_name: ${{ needs.build.outputs.version }}
           prerelease: ${{ github.event_name == 'pull_request' }}
-          tag_name: ${{needs.build.outputs.version}}-${{ needs.build.outputs.release }}
+          tag_name: ${{needs.build.outputs.version}}-${{ steps.package.outputs.tag }}
       - name: Upload Debian Package
         uses: actions/github-script@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/github-script@v2
         with:
           result-encoding: json
-          script: |
+          script: |-
             const fs = require('fs');
             const contentType = 'application/vnd.debian.binary-package';
             const uploadUrl = ''; //'${{ steps.create-release.outputs.upload_url }}';
@@ -78,7 +78,7 @@ jobs:
                   file: fs.readFileSync(file)
                 };
                 core.info(`${inputs}`);
-                #const response = await github.repos.uploadReleaseAsset(inputs);
+                //const response = await github.repos.uploadReleaseAsset(inputs);
               }
             }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           EOF
       - name: Fixup Package Versions and Filenames
         id: fixup
-        run: find . -type f -name "*.deb" -execdir bash ${{ github.workspace }}/fixup.sh {} +
+        run: find . -type f -name "*.deb" -execdir bash ${{ github.workspace }}/fixup.sh {} \;
       #- name: Create Release
       #  uses: actions/create-release@v1
       #  id: create-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
             sed -i '$s:netlify.*:${{ needs.build.outputs.release}}:' tmp/DEBIAN/control
             fakeroot dpkg-deb --build tmp temporary.deb
             fakeroot dpkg-name temporary.deb
-            rm ${package}
+            rm ${filename}
             popd
           done
       #- name: Create Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Netlify TrafficServer
+name: Build
 on:
   push:
     branches:
@@ -9,6 +9,8 @@ on:
       - readme-and-settings
       - 7.1.x-netlify
       - 9.0.x-netlify
+  schedule:
+    - cron: '5, 1,12 * * *'
 jobs:
   package:
     name: Package
@@ -20,18 +22,44 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: packages
+      - name: Create Filename Suffix
+        id: info
+        run: |-
+          revision= $(date -u +'%Y.%m.%d')~
+          tag=$(git rev-parse --short ${{github.sha}})
+          echo "::set-output name=release::+netlify-${revision}~${tag}"
       - name: Display structure of downloaded files
         run: ls -R
-        #- name: Create Release
-        #  uses: actions/create-release@v1
-        #  run: echo TODO
-        #- name: Upload Debian Package
-        #  uses: actions/upload-release-asset@v1
-        #  with:
-        #    upload_url: ${{ steps.create-release.outputs.upload_url }}
-        #    asset_content_type: application/vnd.debian.binary-package
-        #    asset_name: ${{ needs.build.outputs.filename }}
-        #    #          asset_path:
+      - name: Display Build Step Outputs
+        run: echo "release: ${{ needs.build.outputs.release }}"
+        run: echo "version: ${{ needs.build.outputs.version }}"
+      #      - name: Create Release
+      #        uses: actions/create-release@v1
+      #        id: create-release
+      # We can't use upload-release-asset because there are multiple files
+      #- name: Upload Debian Package
+      #  uses: actions/github-script@v2
+      #  with:
+      #    #result-encoding: json
+      #    script: |
+      #      const fs = require('fs');
+      #      const contentType = 'application/vnd.debian.binary-package';
+      #      const uploadUrl = '${{ steps.create-release.outputs.upload_url }}';
+      #      // Get each file that we've uploaded as an artifact
+      #      fs.readdirSync(`${process.env.GITHUB_WORKSPACE}/packages`).forEach(file => {
+      #        const contentLength = fs.statSync(file).size;
+      #        const headers = { 'content-type': contentType, 'content-length': contentLength };
+      #        const inputs = {
+      #          url: uploadUrl,
+      #          headers,
+      #          name: assetName,
+      #          file: fs.readFileSync(file)
+      #        };
+      #        core.info(`${inputs}`);
+      #        #const response = await github.repos.uploadReleaseAsset(inputs);
+      #      });
+      #- name: Create Release
+      #  uses: actions/create-release@v1
   build:
     name: Build
     runs-on: ubuntu-20.04
@@ -54,7 +82,8 @@ jobs:
       CXX: g++-9
       CC: gcc-9
     outputs:
-      release: ${{ steps.info.release }}
+      version: ${{ steps.info.outputs.version }}
+      release: ${{ steps.info.outputs.release }}
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v2
@@ -125,23 +154,21 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         shell: bash
         id: info
-        run: |- # TODO: Come up with better variable names 😬
+        run: |-
           traffic_ctl=$(find $PWD -name traffic_ctl \( ! -regex '.*/\..*' \) -type f -executable)
-          upstream=$(${traffic_ctl} --version | sed -E 's/[^0-9]+(([0-9]+[.]){2}[0-9]+).*$/\1/')
-          revision=$(date +'%Y.%m.%d')
-          tag=$(date -u --date="1970-01-01 UTC $(date -u +%T)" +%s)
-          version=${upstream}+netlify-${revision}~${tag}
-          release=${upstream}+$(date +'%F.%T')
-          echo "::set-output name=package::${{ matrix.package-name }}_${version}_amd64"
-          echo "::set-output name=release::${upstream}+$(date +'%F.%T')"
+          seconds=$(date -u --date="1970-01-01 UTC $(date -u +%T)" +%s)
+          release=netlify+$(date +'%Y.%m.%d')~${seconds}
+          version=$(${traffic_ctl} --version | sed -E 's/[^0-9]+(([0-9]+[.]){2}[0-9]+).*$/\1/')
+          echo "::set-output name=filename::${{ matrix.package-name }}_${version}_amd64"
           echo "::set-output name=version::${version}"
+          echo "::set-output name=release::${release}"
       - name: Install to Staging Area
-        run: make install DESTDIR=${{github.workspace}}/${{ steps.info.outputs.package }}
+        run: make install DESTDIR=${{github.workspace}}/${{ steps.info.outputs.filename }}
         working-directory: ${{ github.workspace }}/build
       - name: Generate Package Manifest # NOTE: We use an epoch (1:) because we differ from ubuntu versioning
         run: |-
-          mkdir -p ${{steps.info.outputs.package}}/DEBIAN
-          tee ${{steps.info.outputs.package}}/DEBIAN/control <<- EOF
+          mkdir -p ${{steps.info.outputs.filename}}/DEBIAN
+          tee ${{steps.info.outputs.filename}}/DEBIAN/control <<- EOF
           Package: netlify-${{ matrix.package-name}}
           Section: devel
           Priority: optional
@@ -161,10 +188,10 @@ jobs:
           Breaks: ${{ matrix.package-name }}
           Description: Netlify TrafficServer Distribution
            This is the Netlify Inc. fork of Apache TrafficServer.
-          Version: 1:${{ steps.info.outputs.version }}
+          Version: 1:${{ steps.info.outputs.version }}-${{steps.info.outputs.release}}
           EOF
       - name: Create Debian Package
-        run: dpkg-deb --build --verbose ${{ steps.info.outputs.package }}
+        run: dpkg-deb --build --verbose ${{ steps.info.outputs.filename }}
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          release_name: ${{ needs.build.outputs.version }}
+          release_name: ${{ needs.build.outputs.version }}-${{steps.package.outputs.tag}}
           prerelease: ${{ github.event_name == 'pull_request' }}
           tag_name: ${{needs.build.outputs.version}}-${{ steps.package.outputs.tag }}
       - name: Upload Debian Package
@@ -72,27 +72,27 @@ jobs:
             const fs = require('fs');
             const contentType = 'application/vnd.debian.binary-package';
             const uploadUrl = '${{ steps.create-release.outputs.upload_url }}';
-            const directories = ['Debug', 'Release', 'RelWithDebInfo']
-              .flatMap(build => [`trafficserver-dev-${build}`, `trafficserver-${build}`]);
-            // Get each file that we've uploaded as an artifact
-            for (const directory of directories) {
-              for (const file of fs.readdirSync(`${{github.workspace}}/packages/${directory}`)) {
-                const path = `${{github.workspace}}/packages/${directory}/${file}`
-                core.info(`Reading ${path}`)
-                const contentLength = fs.statSync(path).size;
-                core.info(`contentLength: ${contentLength}`);
-                const headers = { 'content-type': contentType, 'content-length': contentLength };
-                const inputs = {
-                  url: uploadUrl,
-                  headers,
-                  label: directory,
-                  name: file,
-                  file: fs.readFileSync(path)
-                };
-                const {
-                  data: { browser_download_url: download_url }
-                } = await github.repos.uploadReleaseAsset(inputs);
-                core.info(`Asset ${file} with label ${directory} is available at ${download_url}`);
+            for (const build_type of ['Debug', 'Release', 'RelWithDebInfo']) {
+              // Get each file that we've uploaded as an artifact
+              for (const directory of [`trafficserver-dev-${build_type}`, `trafficserver-${build_type}`]) {
+                for (const file of fs.readdirSync(`${{github.workspace}}/packages/${directory}`)) {
+                  const path = `${{github.workspace}}/packages/${directory}/${file}`
+                  core.info(`Reading ${path}`)
+                  const contentLength = fs.statSync(path).size;
+                  core.info(`contentLength: ${contentLength}`);
+                  const headers = { 'content-type': contentType, 'content-length': contentLength };
+                  const inputs = {
+                    url: uploadUrl,
+                    headers,
+                    label: directory,
+                    name: `${build_type}-${file}`,
+                    data: fs.readFileSync(path)
+                  };
+                  const {
+                    data: { browser_download_url: download_url }
+                  } = await github.repos.uploadReleaseAsset(inputs);
+                  core.info(`Asset ${file} with label ${directory} is available at ${download_url}`);
+                }
               }
             }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,24 +22,27 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: packages
+      - name: Display Artifacts
+        run: ls -R
       - name: Display Build Step Outputs
         run: |-
           echo "release: ${{ needs.build.outputs.release }}"
           echo "version: ${{ needs.build.outputs.version }}"
-      - name: Fixup Package Versions and Filenames
-        id: fixup
+      - name: Generate Fixup Script
         run: |-
           tee fixup.sh <<- EOF
             set -e
-            echo Fixing up $PWD/$(basename $1)
+            echo Fixing up ${{ github.workspace }}/$(basename $1)
             fakeroot mkdir -p tmp
             fakeroot dpkg-deb -R $1 tmp
             sed -i '$s:netlify.*:${{ needs.build.outputs.release}}:' tmp/DEBIAN/control
             fakeroot dpkg-deb --build tmp temporary.deb
             fakeroot dpkg-name temporary.deb
-            rm $PWD/$1 # prevent duplicates
+            rm $1 # prevent duplicates
           EOF
-          find . -type f -name "*.deb" -execdir bash $PWD/fixup.sh {} +
+      - name: Fixup Package Versions and Filenames
+        id: fixup
+        run: find . -type f -name "*.deb" -execdir bash ${{ github.workspace }}/fixup.sh {} +
       #- name: Create Release
       #  uses: actions/create-release@v1
       #  id: create-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,41 +26,55 @@ jobs:
         run: |-
           echo "release: ${{ needs.build.outputs.release }}"
           echo "version: ${{ needs.build.outputs.version }}"
-      - name: Create Filename Suffix
-        id: info
+      - name: Fixup Package Versions and Filenames
+        id: fixup
         run: |-
-          revision=$(date -u +'%Y.%m.%d')
-          #tag=$(git rev-parse --short ${{github.sha}})
-          echo "::set-output name=release::+netlify-${revision}~${tag}"
-      - name: Display structure of downloaded files
-        run: ls -R
-      #      - name: Create Release
-      #        uses: actions/create-release@v1
-      #        id: create-release
-      # We can't use upload-release-asset because there are multiple files
-      #- name: Upload Debian Package
-      #  uses: actions/github-script@v2
-      #  with:
-      #    #result-encoding: json
-      #    script: |
-      #      const fs = require('fs');
-      #      const contentType = 'application/vnd.debian.binary-package';
-      #      const uploadUrl = '${{ steps.create-release.outputs.upload_url }}';
-      #      // Get each file that we've uploaded as an artifact
-      #      fs.readdirSync(`${process.env.GITHUB_WORKSPACE}/packages`).forEach(file => {
-      #        const contentLength = fs.statSync(file).size;
-      #        const headers = { 'content-type': contentType, 'content-length': contentLength };
-      #        const inputs = {
-      #          url: uploadUrl,
-      #          headers,
-      #          name: assetName,
-      #          file: fs.readFileSync(file)
-      #        };
-      #        core.info(`${inputs}`);
-      #        #const response = await github.repos.uploadReleaseAsset(inputs);
-      #      });
+          tee fixup.sh <<- EOF
+            set -e
+            echo Fixing up $PWD/$(basename $1)
+            fakeroot mkdir -p tmp
+            fakeroot dpkg-deb -R $1 tmp
+            sed -i '$s:netlify.*:${{ needs.build.outputs.release}}:' tmp/DEBIAN/control
+            fakeroot dpkg-deb --build tmp temporary.deb
+            fakeroot dpkg-name temporary.deb
+            rm $PWD/$1 # prevent duplicates
+          EOF
+          find . -type f -name "*.deb" -execdir bash $PWD/fixup.sh {} +
       #- name: Create Release
       #  uses: actions/create-release@v1
+      #  id: create-release
+      #  with:
+      #    release_name: ${{ needs.build.outputs.version }}
+      #    prerelease: ${{ github.event_name == "pull_request" }}
+      #    tag_name: ${{ github.ref }}
+      # We can't use upload-release-asset because there are multiple files
+      - name: Upload Debian Package
+        uses: actions/github-script@v2
+        with:
+          result-encoding: json
+          script: |
+            const fs = require('fs');
+            const contentType = 'application/vnd.debian.binary-package';
+            const uploadUrl = '';#'${{ steps.create-release.outputs.upload_url }}';
+            const directories = ['Debug', 'Release', 'RelWithDebInfo']
+              .flatMap(build => [`trafficserver-dev-${build}`, `trafficserver-${build}`]);
+
+            // Get each file that we've uploaded as an artifact
+            for (const directory of directories) {
+              for (const file of fs.readdirSync(`${{github.workspace}}/packages/${directory}`)) {
+                const contentLength = fs.statSync(file).size;
+                const headers = { 'content-type': contentType, 'content-length': contentLength };
+                const inputs = {
+                  url: uploadUrl,
+                  headers,
+                  name: file,
+                  file: fs.readFileSync(file)
+                };
+                core.info(`${inputs}`);
+                #const response = await github.repos.uploadReleaseAsset(inputs);
+              }
+            }
+
   build:
     name: Build
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
             pushd ${directory}
             echo Fixing up ${package}
             fakeroot mkdir -p tmp
-            fakeroot dpkg-deb -R ${package} tmp
+            fakeroot dpkg-deb -R ${filename} tmp
             sed -i '$s:netlify.*:${{ needs.build.outputs.release}}:' tmp/DEBIAN/control
             fakeroot dpkg-deb --build tmp temporary.deb
             fakeroot dpkg-name temporary.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,9 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
       - name: Display Build Step Outputs
-        run: echo "release: ${{ needs.build.outputs.release }}"
-        run: echo "version: ${{ needs.build.outputs.version }}"
+        run: |-
+          echo "release: ${{ needs.build.outputs.release }}"
+          echo "version: ${{ needs.build.outputs.version }}"
       #      - name: Create Release
       #        uses: actions/create-release@v1
       #        id: create-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,18 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: packages
-      - name: Create Filename Suffix
-        id: info
-        run: |-
-          revision= $(date -u +'%Y.%m.%d')~
-          #tag=$(git rev-parse --short ${{github.sha}})
-          echo "::set-output name=release::+netlify-${revision}~${tag}"
-      - name: Display structure of downloaded files
-        run: ls -R
       - name: Display Build Step Outputs
         run: |-
           echo "release: ${{ needs.build.outputs.release }}"
           echo "version: ${{ needs.build.outputs.version }}"
+      - name: Create Filename Suffix
+        id: info
+        run: |-
+          revision=$(date -u +'%Y.%m.%d')
+          #tag=$(git rev-parse --short ${{github.sha}})
+          echo "::set-output name=release::+netlify-${revision}~${tag}"
+      - name: Display structure of downloaded files
+        run: ls -R
       #      - name: Create Release
       #        uses: actions/create-release@v1
       #        id: create-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,9 @@ jobs:
             for (const directory of directories) {
               for (const file of fs.readdirSync(`${{github.workspace}}/packages/${directory}`)) {
                 const path = `${{github.workspace}}/packages/${directory}/${file}`
+                core.info(`Reading ${path}`)
                 const contentLength = fs.statSync(path).size;
+                core.info(`contentLength: ${contentLength}`);
                 const headers = { 'content-type': contentType, 'content-length': contentLength };
                 const inputs = {
                   url: uploadUrl,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         id: info
         run: |-
           revision= $(date -u +'%Y.%m.%d')~
-          tag=$(git rev-parse --short ${{github.sha}})
+          #tag=$(git rev-parse --short ${{github.sha}})
           echo "::set-output name=release::+netlify-${revision}~${tag}"
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
             fakeroot dpkg-deb --build tmp temporary.deb
             fakeroot dpkg-name temporary.deb
             rm ${filename}
+            rm -r tmp
             popd
           done
       #- name: Create Release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Apache Traffic Server
 Traffic Server is a high-performance building block for cloud services.  It's more than just a caching proxy server; it also has support for plugins to build large scale web applications.
 
+![Build](https://github.com/netlify/trafficserver/workflows/Build/badge.svg)
+
 See https://trafficserver.apache.org or upstream [apache/trafficserver](https://github.com/apache/trafficserver) for more information.
 
 # This Fork


### PR DESCRIPTION
Found some additional bugs over the weekend. Can't test locally (the only 'tool' out there that might let us doesn't provide Ubuntu 20.04 😟), so we're running some tests on what outputs actually get output from the 'release', which differs between builds.

We're also going to add a badge to the readme, so we can see at a glance what the build is looking like (Some adjustments are needed for per-branch build state)

We might also not need the cron command. That or some work is needed to figure out if anything changed vs the last build when cron is run.