### PR TITLE
🐛 Fix incorrect install dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,8 +211,8 @@ jobs:
           Architecture: amd64
           Maintainer: Isabella Muerte <imuerte>
           Depends: libssl1.1,
-            libluajit-5.1.2,
-            libhwlock15,
+            libluajit-5.1-2,
+            libhwloc15,
             libunwind8,
             libgeoip1,
             libcurl4,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,7 @@ jobs:
             libhwloc15,
             libunwind8,
             libgeoip1,
+            libtcl8.6,
             libcurl4,
             liblzma5,
             libpcre3,


### PR DESCRIPTION
This resolves two typos found in the `Depends:` field for the package.