### PR TITLE
Add postinst script to fix permission issues.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,6 +208,7 @@ jobs:
             #!/bin/bash
             chown -R nobody:nogroup /opt/ts/var/log/trafficserver
           EOF
+          chmod 555 ${{steps.info.outputs.filename}}/DEBIAN/postinst
           tee ${{steps.info.outputs.filename}}/DEBIAN/control <<- EOF
           Package: netlify-${{ matrix.package-name}}
           Section: devel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,6 +204,10 @@ jobs:
       - name: Generate Package Manifest # NOTE: We use an epoch (1:) because we differ from ubuntu versioning
         run: |-
           mkdir -p ${{steps.info.outputs.filename}}/DEBIAN
+          tee ${{steps.info.outputs.filename}}/DEBIAN/postinst <<- EOF
+            #!/bin/bash
+            chown -R nobody:nogroup /opt/ts/var/log/trafficserver
+          EOF
           tee ${{steps.info.outputs.filename}}/DEBIAN/control <<- EOF
           Package: netlify-${{ matrix.package-name}}
           Section: devel


### PR DESCRIPTION
This is what the official installer does to get the right access to
write logs in the default directory.

Signed-off-by: David Calavera <david.calavera@gmail.com>