### PR TITLE
🐛 Fix running ATS as root

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -29,8 +29,6 @@ override_dh_auto_configure:
 		--sysconfdir=\$${prefix}/etc/trafficserver \
 		--libdir=\$${prefix}/lib/trafficserver \
 		--libexecdir=\$${prefix}/libexec/trafficserver/modules \
-		--with-user=root \
-		--with-group=root \
 		--enable-layout=Debian \
 		--enable-wccp \
 		$(if $(filter debug,$(DEB_BUILD_PROFILES)),--enable-debug) \


### PR DESCRIPTION
We still need to check what it will be run/installed as, but if we need to set the group/user to nobody:nobody, that is also an easy fix and can be put into this PR. I'll be doing a local test with the produced package from this PR.

This should allow us to fix the deploy issue we ran into regarding the netlify/ats-docker#126 test deployment.

For posterity, the reason `--with-user=root` and `--with-group=root` were added is because the official debian packaging does this (and also assumes users would not run ATS as root).