### PR TITLE
🐛 Fix plugin install directory

### DIFF
--- a/debian/netlify-trafficserver-dev.install
+++ b/debian/netlify-trafficserver-dev.install
@@ -1,4 +1,4 @@
 opt/ts/bin/tsxs
 opt/ts/include/*
-opt/ts/lib/trafficserver/lib*.so
-opt/ts/lib/trafficserver/pkgconfig/trafficserver.pc
+opt/ts/lib/lib*.so
+opt/ts/lib/pkgconfig/trafficserver.pc

--- a/debian/netlify-trafficserver.install
+++ b/debian/netlify-trafficserver.install
@@ -1,6 +1,6 @@
 opt/ts/bin/traffic*
 opt/ts/bin/tspush
-opt/ts/lib/trafficserver/lib*.so.*
-opt/ts/libexec/trafficserver/modules/*.so
+opt/ts/lib/lib*.so.*
+opt/ts/libexec/trafficserver/*.so
 opt/ts/lib/perl5/*
 opt/ts/etc/trafficserver/*

--- a/debian/rules
+++ b/debian/rules
@@ -42,3 +42,6 @@ override_dh_auto_install:
 
 override_dh_builddeb:
 	dh_builddeb --destdir=${GITHUB_WORKSPACE}
+
+# Skip installexamples
+override_dh_installexamples:

--- a/debian/rules
+++ b/debian/rules
@@ -27,8 +27,8 @@ override_dh_auto_configure:
 		--config-cache \
 		--prefix=${NETLIFY_PREFIX} \
 		--sysconfdir=\$${prefix}/etc/trafficserver \
-		--libdir=\$${prefix}/lib/trafficserver \
-		--libexecdir=\$${prefix}/libexec/trafficserver/modules \
+		--libexecdir=\$${prefix}/libexec/trafficserver \
+		--libdir=\$${prefix}/lib \
 		--enable-layout=Debian \
 		--enable-wccp \
 		$(if $(filter debug,$(DEB_BUILD_PROFILES)),--enable-debug) \


### PR DESCRIPTION
🐛 Fix library install directory

This does break with the existing approach regarding how upstream installs, however it's what our tools currently expect (and won't be a breaking change for our CMake code)