### PR TITLE
Backport: remap.config .include files trigger reloads

### DIFF
--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -88,6 +88,7 @@ extern "C" int plock(int);
 #include "DiagsConfig.h"
 #include "CoreUtils.h"
 #include "congest/Congestion.h"
+#include "RemapConfig.h"
 #include "RemapProcessor.h"
 #include "I_Tasks.h"
 #include "InkAPIInternal.h"
@@ -125,6 +126,7 @@ static void *mgmt_storage_device_cmd_callback(void *x, char *data, int len);
 static void *mgmt_lifecycle_msg_callback(void *x, char *data, int len);
 static void init_ssl_ctx_callback(void *ctx, bool server);
 static void load_ssl_file_callback(const char *ssl_file, unsigned int options);
+static void load_remap_file_callback(const char *remap_file);
 
 static int num_of_net_threads = ink_number_of_processors();
 static int num_of_udp_threads = 0;
@@ -1687,11 +1689,15 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     ::exit(0);
   }
 
+  // setup callback for tracking remap included files
+  load_remap_file_cb = load_remap_file_callback;
+
   // We need to do this early so we can initialize the Machine
   // singleton, which depends on configuration values loaded in this.
   // We want to initialize Machine as early as possible because it
   // has other dependencies. Hopefully not in init_HttpProxyServer().
   HttpConfig::startup();
+
   /* Set up the machine with the outbound address if that's set,
      or the inbound address if set, otherwise let it default.
   */
@@ -2052,4 +2058,10 @@ static void
 load_ssl_file_callback(const char *ssl_file, unsigned int options)
 {
   pmgmt->signalConfigFileChild("ssl_multicert.config", ssl_file, options);
+}
+
+static void
+load_remap_file_callback(const char *remap_file)
+{
+  pmgmt->signalConfigFileChild("remap.config", remap_file, CONFIG_FLAG_UNVERSIONED);
 }

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -37,6 +37,8 @@
 
 static bool remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti);
 
+load_remap_file_func load_remap_file_cb = nullptr;
+
 /**
   Returns the length of the URL.
 
@@ -286,17 +288,17 @@ parse_remap_fragment(const char *path, BUILD_TABLE_INFO *bti, char *errbuf, size
   nbti.rules_list = bti->rules_list;
   nbti.rewrite    = bti->rewrite;
 
-  // XXX at this point, we need to register the included file(s) with the management subsystem
-  // so that we can correctly reload them when they change. Otherwise, the operator will have to
-  // touch remap.config before reloading the configuration.
-
   Debug("url_rewrite", "[%s] including remap configuration from %s", __func__, (const char *)path);
   success = remap_parse_config_bti(path, &nbti);
 
   // The sub-parse might have updated the rules list, so push it up to the parent parse.
   bti->rules_list = nbti.rules_list;
 
-  if (!success) {
+  if (success) {
+    // register the included file with the management subsystem so that we can correctly
+    // reload them when they change
+    load_remap_file_cb((const char *)path);
+  } else {
     snprintf(errbuf, errbufsize, "failed to parse included file %s", path);
     return (const char *)errbuf;
   }

--- a/proxy/http/remap/RemapConfig.h
+++ b/proxy/http/remap/RemapConfig.h
@@ -74,3 +74,7 @@ unsigned long remap_check_option(const char **argv, int argc, unsigned long find
                                  const char **argptr = NULL);
 
 bool remap_parse_config(const char *path, UrlRewrite *rewrite);
+
+typedef void (*load_remap_file_func)(const char *);
+
+extern load_remap_file_func load_remap_file_cb;


### PR DESCRIPTION
*Backports https://github.com/apache/trafficserver/pull/4308*

Without this, we were not able to reload the `remap.config` when using the `.include` directive.

> Previous behavior required operator to touch toplevel remap.config
> to trigger reload if the operator modified an included remap file.