### PR TITLE
🔨 Enable AVX2 compiler codegen optimizations

### DIFF
--- a/debian/profiles.mk
+++ b/debian/profiles.mk
@@ -4,7 +4,5 @@
 profiles :=
 
 profiles += $(if $(filter relwithdebinfo, $(DEB_BUILD_PROFILES)), -O2 -ggdb -DNDEBUG)
-profiles += $(if $(filter release, $(DEB_BUILD_PROFILES)), -O2 -DNDEBUG)
+profiles += $(if $(filter release, $(DEB_BUILD_PROFILES)), -O3 -DNDEBUG)
 profiles += $(if $(filter debug, $(DEB_BUILD_PROFILES)), -Og -UNDEBUG -ggdb -fno-omit-frame-pointer)
-
-

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ MAKE_DIRECTORY := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 include ${MAKE_DIRECTORY}/diagnostics.mk
 include ${MAKE_DIRECTORY}/profiles.mk
 
-export DEB_CXXFLAGS_MAINT_PREPEND = -std=c++17 -Dmy_bool=int
+export DEB_CXXFLAGS_MAINT_PREPEND = -std=c++17 -Dmy_bool=int -mavx2
 export DEB_CXXFLAGS_MAINT_APPEND = $(diagnostics) $(profiles)
 # Currently 7.1.x cannot correctly link without it
 #export DEB_LDFLAGS_MAINT_APPEND = -fuse-ld=lld


### PR DESCRIPTION
netlify/ansible#3976 has been closed and we can now rely on avx2 code generation.

This also fixes that release used `-O2` instead of `-O3`. While the default trafficserver build uses `-O2`, we were originally using `-O3`. This shouldn't affect anything but enable a few extra optimizations and could result in larger release binaries by a few hundred kb.

`-O3` is needed to allow gcc (and clang!) to perform some peephole optimizations and turn some for-loops into "vectorized for enabled compiler extensions" code. (because we turn on `-mavx2`, this means AVX2 optimizations)

This does not affect things like `std::memcpy` or other libraries. Those would technically have to be recompiled from source, but for trafficserver specific code it does enable these optimizations