### PR TITLE
TSCont destroy and scheduling fix

### DIFF
--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -84,7 +84,10 @@ TS_INLINE Event *
 EThread::schedule(Event *e, bool fast_signal)
 {
   e->ethread = this;
-  ink_assert(tt == REGULAR);
+  if (tt != REGULAR) {
+    ink_assert(tt == DEDICATED);
+    return eventProcessor.schedule(e, ET_CALL);
+  }
   if (e->continuation->mutex)
     e->mutex = e->continuation->mutex;
   else

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -1010,7 +1010,7 @@ INKContInternal::destroy()
     if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
       ink_assert(!"not reached");
     }
-    this_ethread()->schedule_imm(this);
+    this_ethread()->schedule_imm_local(this);
   }
 }
 

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -1010,7 +1010,7 @@ INKContInternal::destroy()
     if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
       ink_assert(!"not reached");
     }
-    this_ethread()->schedule_imm_local(this);
+    this_ethread()->schedule_imm(this);
   }
 }
 


### PR DESCRIPTION
This allows us to call `TSContDestroy` from tokio threads. This operation currently (debug) asserts because our tokio threads are registered with ATS as 'dedicated' `EThreads`. These do not host an executor, so scheduling events on them is a nonsensical operation. This isn't a release assert, so this is failing silently in production.

The second commit here changes the upstream `EThread::schedule` function to schedule events from dedicated `EThreads` on the `ET_CALL` threadpool. This strategy is already in place for `EThread::schedule_local`. This allows us to destroy continuations from tokio (and use other similar functions).

The first commit changes `INKContInternal::destroy` to use `EThread::schedule_local`. The `destroy` function typically schedules an event on the current `EThread`, so the non-signalling `schedule_local` call is appropriate. This variant also happens to properly handle calls from dedicated `EThreads`.

I believe both of these changes are reasonable, but either will fix our assert.

This PR should be held until upstream review is complete - https://github.com/apache/trafficserver/pull/7228 + https://github.com/apache/trafficserver/pull/7229