### PR TITLE
Build netlify branches when we merge changes in them.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,11 @@ on:
       - readme-and-settings
       - 7.1.x-netlify
       - 9.0.x-netlify
+  push:
+    branches:
+      - 7.1.x-netlify
+      - 9.0.x-netlify
+
 env:
   DEBFULLNAME: "github-actions[bot]"
   DEBEMAIL: "41898282+github-actions[bot]@users.noreply.github.com"

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -4040,7 +4040,7 @@ TSCacheKeyDigestFromUrlSet(TSCacheKey key, TSMLoc url)
     return TS_ERROR;
   }
 
-  url_MD5_get((URLImpl *)url, &((CacheInfo *)key)->cache_key);
+  url_CryptoHash_get((URLImpl *)url, &((CacheInfo *)key)->cache_key);
   return TS_SUCCESS;
 }
 


### PR DESCRIPTION
That way we can backport things, and build  new deb packages as soon as changes get merged.

Signed-off-by: David Calavera <david.calavera@gmail.com>