### PR TITLE
Revert "Let Dedicated EThreads use `EThread::schedule`"

### DIFF
--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -84,10 +84,7 @@ TS_INLINE Event *
 EThread::schedule(Event *e, bool fast_signal)
 {
   e->ethread = this;
-  if (tt != REGULAR) {
-    ink_assert(tt == DEDICATED);
-    return eventProcessor.schedule(e, ET_CALL);
-  }
+  ink_assert(tt == REGULAR);
   if (e->continuation->mutex)
     e->mutex = e->continuation->mutex;
   else


### PR DESCRIPTION
_Note: this issue is public._

The reverted commit allows `DEDICATED` plugin threads to schedule continuations rather than failing silently. I theorize that the deadlock-like events observed on the beta network have been caused by traffic-mesh hitting an unsolved locking issue. Reverting this commit is a poor workaround, but it is acceptable given the current plan to deploy traffic-mesh outside of ATS. I'll investigate further if this issue continues or if the traffic-mesh deployment plan changes.