### PR TITLE
support prefix branch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
       - readme-and-settings
       - 9.0.x-netlify
       - 9.1.x-netlify
+      - netlify/*
 env:
   DEBFULLNAME: 'github-actions[bot]'
   DEBEMAIL: '41898282+github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
https://github.com/netlify/trafficserver/pull/1577 didn't seem to trigger a build b/c it wasn't in the named list of branches that are in this config. I'm hoping that by adding this (and renaming that branch) we can trigger it. 

I'm def not certain this is the best way. 