### PR TITLE
Fix use of deprecated directive in CI flows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,9 @@ jobs:
         id: datetime
         run: |-
           time=$(date --date "1970-01-01 $(date +%T)" +%s)
-          echo "::set-output name=timestamp::$(date --iso-8601=seconds)"
-          echo "::set-output name=date::$(date --utc +%Y.%m.%d)"
-          echo "::set-output name=time::${time}"
+          echo "timestamp=$(date --iso-8601=seconds)" >> $GITHUB_OUTPUT
+          echo "date=$(date --utc +%Y.%m.%d)" >> $GITHUB_OUTPUT
+          echo "time=${time}" >> $GITHUB_OUTPUT
   build:
     name: Build Netlify TrafficServer
     needs: calendar

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,8 +19,7 @@ jobs:
     steps:
       - name: Get Current Date
         id: datetime
-        run: |-
-          echo "::set-output name=date::$(date +%s)"
+        run: echo "date=$(date +%s)" >> $GITHUB_OUTPUT
   build:
     name: Build TrafficServer
     needs: calendar


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/